### PR TITLE
Check for version 3.0.0 before checking for version 2.6.0 when choosing ...

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -108,10 +108,10 @@ class mongodb::server::config {
     #Pick which config content to use
     if $config_content {
       $cfg_content = $config_content
-    } elsif (versioncmp($mongodb::globals::version, '2.6.0') >= 0) {
-      $cfg_content = template('mongodb/mongodb.conf.2.6.erb')
     } elsif (versioncmp($mongodb::globals::version, '3.0.0') >= 0) {
       $cfg_content = template('mongodb/mongodb.conf.3.0.erb')
+    } elsif (versioncmp($mongodb::globals::version, '2.6.0') >= 0) {
+      $cfg_content = template('mongodb/mongodb.conf.2.6.erb')
     } else {
       $cfg_content = template('mongodb/mongodb.conf.erb')
     }


### PR DESCRIPTION
Check for version 3.0.0 before checking for version 2.6.0 when choosing a template for mongodb.conf, otherwise you'll end up with a 2.6 template for a 3.x server
