### PR TITLE
Fixes setting  node as an arbiter.

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -190,7 +190,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
       hostconf = alive_hosts.each_with_index.map do |host,id|
         arbiter_conf = ""
         if rs_arbiter == host
-          arbiter_conf = ", arbiterOnly: \"true\""
+          arbiter_conf = ", arbiterOnly: true"
         end
         "{ _id: #{id}, host: \"#{host}\"#{arbiter_conf} }"
       end.join(',')


### PR DESCRIPTION
Fixes ... Error: /Stage[main]/Mongodb::Replset/Mongodb_replset[rs0]: …Could not evaluate: rs.initiate() failed for replicaset rs0: Expected boolean or number type for field 'arbiterOnly', found String
